### PR TITLE
fix cases when some categories are empty

### DIFF
--- a/OCRBench_v2/eval_scripts/eval.py
+++ b/OCRBench_v2/eval_scripts/eval.py
@@ -359,7 +359,7 @@ def process_predictions(input_path, output_path):
                 total_len += 1
                 mean_score += item["score"]
         
-        mean_score = mean_score / total_len
+        mean_score = mean_score / total_len if total_len > 0 else 0
         print(f"Task {task_name}, total instructions: {total_len}, average score: {mean_score:.3f}\n")
 
     with open(output_path, 'w', encoding='utf-8') as file:


### PR DESCRIPTION
Hi thanks for the great works.

Evaluation expect predictions for all categories. 
This is a quick fix to allow the evaluation to work even if some categories are left empty (no predictions)